### PR TITLE
add support for binding to specific interfaces

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,6 +76,7 @@ app.use(function (err, req, res, next) {
 });
 
 module.exports = app;
+module.exports.glass_config = glass_config;
 
 /**
  * Global Variables

--- a/bin/www
+++ b/bin/www
@@ -12,7 +12,8 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.PORT || app.glass_config.port || '3000');
+var interface = app.glass_config.host || '0.0.0.0';
 app.set('port', port);
 
 /**
@@ -25,7 +26,7 @@ var server = http.createServer(app);
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
+server.listen(port, interface);
 server.on('error', onError);
 server.on('listening', onListening);
 


### PR DESCRIPTION
This allows someone to add host and port entries to the glass_config
file to change the default port, or bind to a specific interface.

For example:

 "host": "127.0.0.1",
 "port": "3000",

If you only want to bind on the local interface.