### PR TITLE
getting host_name from /usr/bin/env hostname

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,7 +109,11 @@ global.socket_clients                 = 0;
 /**
  * Server hostname
  */
-global.host_name = execSync("cat /etc/hostname").toString().replace("\n", "");
+try {
+    global.host_name = execSync("cat /etc/hostname").toString().replace("\n", "");
+} catch (e) {
+    global.host_name = execSync("/usr/bin/env hostname -s").toString().replace("\n", "");
+}
 
 /**
  * Pull in core handlers


### PR DESCRIPTION
FreeBSD does not have an `/etc/hostname` file, but provides a binary `hostname` for it. 
If we can't find an /etc/hostname file, we try to use `/usr/bin/env hostname`