### PR TITLE
Preventing some errors and showing all leases without search

### DIFF
--- a/api/get_mac_oui_count_by_vendor.js
+++ b/api/get_mac_oui_count_by_vendor.js
@@ -10,7 +10,7 @@ router.get('/', function (req, res, next) {
 
 		/* Mac OUI Lookup */
 		var mac_oui = "";
-		if (typeof dhcp_lease_data[key].mac.split(":").join("") !== "undefined") {
+		if (typeof dhcp_lease_data[key].mac !== "undefined") {
 			mac_oui = dhcp_lease_data[key].mac.split(":").join("").toUpperCase().slice(0, 6);
 		}
 

--- a/public/templates/dhcp_leases.html
+++ b/public/templates/dhcp_leases.html
@@ -19,7 +19,13 @@
 </div>
 
 <script type="text/javascript">
-    /*
+        $( document ).ready(function() {
+                var e = jQuery.Event("keypress");
+                e.which = 13; // Enter
+                e.keyCode = 13;
+                $("#lease_search_criteria").trigger(e);
+        });
+        /*
 	$('#display-leases').DataTable({
 		dom: 'tip',
 		responsive: true,

--- a/routes/dhcp_lease_search.js
+++ b/routes/dhcp_lease_search.js
@@ -49,11 +49,14 @@ router.post('/', function(req, res, next) {
         table_row = table_row + '<td>' + (dhcp_lease_data[key].host ? dhcp_lease_data[key].host : '') + '</td>';
         table_row = table_row + '<td>' + human_time(dhcp_lease_data[key].start * 1000) + '</td>';
         table_row = table_row + '<td>' + human_time(dhcp_lease_data[key].end * 1000) + '</td>';
-        table_row = table_row + '<td>' +
+        if (typeof dhcp_lease_data[key].mac !== "undefined" ) {
+          table_row = table_row + '<td>' +
             '<button class="btn btn-default waves-effect option_data" lease="' + dhcp_lease_data[key].mac.split(":").join("") + '">Show</button>' +
             '<pre style="display:none;margin-top:10px" id="' + dhcp_lease_data[key].mac.split(":").join("") + '">' + JSON.stringify(dhcp_lease_data[key].options, null, 2) + '</pre>' +
             '</td>';
-
+        } else {
+          table_row = table_row + '<td></td>';
+        }	
         table_data = table_data + '<tr>' + table_row + '</tr>';
 
         count++;


### PR DESCRIPTION
split would have caused errors on malformed dhcp data. 
dhcp leases should be shown without searching.