### PR TITLE
Ignoring binding states of backup, expired and free

### DIFF
--- a/core/lease-parser.js
+++ b/core/lease-parser.js
@@ -11,6 +11,16 @@ module.exports = {
 			lines = lease_data[i].split("\n");
 			for (l = 0; l < lines.length; l++) {
 
+				if (typeof lines[5] !== "undefined") {
+					if (
+						lines[5].trim() === "binding state backup;" ||
+						lines[5].trim() === "binding state expired;" ||
+						lines[5].trim() === "binding state free;"
+					) {
+					continue;
+				}
+
+
 				/**
 				 * Trim whitespaces at each ends of the line
 				 */

--- a/core/lease-parser.js
+++ b/core/lease-parser.js
@@ -17,7 +17,8 @@ module.exports = {
 						lines[5].trim() === "binding state expired;" ||
 						lines[5].trim() === "binding state free;"
 					) {
-					continue;
+						continue;
+					}
 				}
 
 


### PR DESCRIPTION
Fixes the issue when running isc-dhcp-server witha failover pair, which causes the symptoms highlighted in the following Issue https://github.com/Akkadius/glass-isc-dhcp/issues/65.

This change will now ignore any leases in the lease file which are marked as backup, expired or free.
This will mean that Glass ISC DHCP will be able to correct display the data in the table.

Happy to further discuss changes/ammendments if required.
I created this as I too am having the same issue as in Issue https://github.com/Akkadius/glass-isc-dhcp/issues/65, so thought I'd go ahead and fix it now I've had some free time.

