### PR TITLE
Adding ability to specify a date and time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,10 @@ service apparmor restart
     ""
   ],
   "email_alert_to": "",
-  "sms_alert_to": ""
+  "sms_alert_to": "",
+  "ws_port": 8080,
+  "date_format": "YYYY-MM-DD",
+  "time_format": "HH:mm:ss"
 }
 </pre>
 

--- a/config/glass_config.json
+++ b/config/glass_config.json
@@ -14,5 +14,7 @@
   ],
   "email_alert_to": "",
   "sms_alert_to": "",
-  "ws_port": 8080
+  "ws_port": 8080,
+  "date_format": "YYYY-MM-DD",
+  "time_format": "HH:mm:ss"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -799,7 +799,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -817,11 +818,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -834,15 +837,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -945,7 +951,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -955,6 +962,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -967,17 +975,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -994,6 +1005,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1066,7 +1078,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1076,6 +1089,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1151,7 +1165,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1181,6 +1196,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1198,6 +1214,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1236,11 +1253,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -1921,6 +1940,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "morgan": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
@@ -2445,6 +2469,7 @@
     },
     "safe-buffer": {
       "version": "5.0.1",
+      "resolved": false,
       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
     },
     "safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "jade": "~1.11.0",
     "jsonfile": "^3.0.1",
     "lodash": "^4.17.10",
+    "moment": "^2.29.1",
     "morgan": "^1.9.0",
     "nodemailer": "^4.6.7",
     "serve-favicon": "^2.5.0",

--- a/routes/dhcp_config_snapshots.js
+++ b/routes/dhcp_config_snapshots.js
@@ -5,7 +5,7 @@ var template_render = require('../core/render-template.js');
 var authorize = require('../core/authorize.js');
 var json_file = require('jsonfile');
 var moment = require('moment');
-var glass_config = json_file.readFileSync('../config/glass_config.json');
+var glass_config = json_file.readFileSync('config/glass_config.json');
 
 function human_time (time){
     var humantime = moment(time);

--- a/routes/dhcp_config_snapshots.js
+++ b/routes/dhcp_config_snapshots.js
@@ -3,29 +3,13 @@ var router = express.Router();
 var fs = require('fs');
 var template_render = require('../core/render-template.js');
 var authorize = require('../core/authorize.js');
+var json_file = require('jsonfile');
+var moment = require('moment');
+var glass_config = json_file.readFileSync('../config/glass_config.json');
 
 function human_time (time){
-    var time = new Date(time);
-    var year = time.getFullYear();
-    var month = time.getMonth()+1;
-    var date1 = time.getDate();
-    var hour = time.getHours();
-    var minutes = time.getMinutes();
-    var seconds = time.getSeconds();
-
-    var hour = time.getHours();
-    var minute = time.getMinutes();
-    var amPM = (hour > 11) ? "PM" : "AM";
-    if(hour > 12) {
-        hour -= 12;
-    } else if(hour == 0) {
-        hour = "12";
-    }
-    if(minute < 10) {
-        minute = "0" + minute;
-    }
-
-    return year + "-" + month+"-"+date1+" "+hour + ":" + minute + ' ' + amPM;
+    var humantime = moment(time);
+    return humantime.format(glass_config.date_format + " " + glass_config.time_format)
 }
 
 router.get('/', authorize.auth, function(req, res, next) {

--- a/routes/dhcp_lease_search.js
+++ b/routes/dhcp_lease_search.js
@@ -2,17 +2,13 @@ var express = require('express');
 var router = express.Router();
 var fs = require('fs');
 var template_render = require('../core/render-template.js');
+var json_file = require('jsonfile');
+var moment = require('moment');
+var glass_config = json_file.readFileSync('../config/glass_config.json');
 
 function human_time (time){
-    var time = new Date(time);
-    var year = time.getFullYear();
-    var month = time.getMonth()+1;
-    var date1 = time.getDate();
-    var hour = time.getHours();
-    var minutes = time.getMinutes();
-    var seconds = time.getSeconds();
-
-    return year + "-" + month+"-"+date1+" "+hour+":"+minutes+":"+seconds;
+    var humantime = moment(time);
+    return humantime.format(glass_config.date_format + " " + glass_config.time_format)
 }
 
 router.post('/', function(req, res, next) {

--- a/routes/dhcp_lease_search.js
+++ b/routes/dhcp_lease_search.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var template_render = require('../core/render-template.js');
 var json_file = require('jsonfile');
 var moment = require('moment');
-var glass_config = json_file.readFileSync('../config/glass_config.json');
+var glass_config = json_file.readFileSync('config/glass_config.json');
 
 function human_time (time){
     var humantime = moment(time);

--- a/routes/dhcp_leases.js
+++ b/routes/dhcp_leases.js
@@ -2,17 +2,13 @@ var express = require('express');
 var router = express.Router();
 var fs = require('fs');
 var template_render = require('../core/render-template.js');
+var json_file = require('jsonfile');
+var moment = require('moment');
+var glass_config = json_file.readFileSync('../config/glass_config.json');
 
 function human_time (time){
-	var time = new Date(time);
-	var year = time.getFullYear();
-	var month = time.getMonth()+1;
-	var date1 = time.getDate();
-	var hour = time.getHours();
-	var minutes = time.getMinutes();
-	var seconds = time.getSeconds();
-
-	return year + "-" + month+"-"+date1+" "+hour+":"+minutes+":"+seconds;
+    var humantime = moment(time);
+    return humantime.format(glass_config.date_format + " " + glass_config.time_format)
 }
 
 router.get('/', function(req, res, next) {

--- a/routes/dhcp_leases.js
+++ b/routes/dhcp_leases.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var template_render = require('../core/render-template.js');
 var json_file = require('jsonfile');
 var moment = require('moment');
-var glass_config = json_file.readFileSync('../config/glass_config.json');
+var glass_config = json_file.readFileSync('config/glass_config.json');
 
 function human_time (time){
     var humantime = moment(time);

--- a/routes/dhcp_log.js
+++ b/routes/dhcp_log.js
@@ -2,17 +2,13 @@ var express = require('express');
 var router = express.Router();
 var fs = require('fs');
 var template_render = require('../core/render-template.js');
+var json_file = require('jsonfile');
+var moment = require('moment');
+var glass_config = json_file.readFileSync('../config/glass_config.json');
 
 function human_time (time){
-	var time = new Date(time);
-	var year = time.getFullYear();
-	var month = time.getMonth()+1;
-	var date1 = time.getDate();
-	var hour = time.getHours();
-	var minutes = time.getMinutes();
-	var seconds = time.getSeconds();
-
-	return year + "-" + month+"-"+date1+" "+hour+":"+minutes+":"+seconds;
+    var humantime = moment(time);
+    return humantime.format(glass_config.date_format + " " + glass_config.time_format)
 }
 
 router.get('/', function(req, res, next) {

--- a/routes/dhcp_log.js
+++ b/routes/dhcp_log.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var template_render = require('../core/render-template.js');
 var json_file = require('jsonfile');
 var moment = require('moment');
-var glass_config = json_file.readFileSync('../config/glass_config.json');
+var glass_config = json_file.readFileSync('config/glass_config.json');
 
 function human_time (time){
     var humantime = moment(time);


### PR DESCRIPTION
This gives the user an option to override the default date format using the global glass_config.js file. 
This was requested in the Issue https://github.com/Akkadius/glass-isc-dhcp/issues/67 . I have added the moment library as this aids in parsing and formatting dates with ease.
I have replaced all instances of the human_time function with that using moment instead. The available options for the date/time can be derived from the following options found on the moment documentation: https://momentjs.com/docs/#/displaying/format/

Happy to further discuss changes/amendments if required.
I created this as I wanted to tweak the date/time formats myself as requested in Issue https://github.com/Akkadius/glass-isc-dhcp/issues/67, so thought I'd go ahead and fix it now I've had some free time.