### PR TITLE
Changed trigger for mac address line to avoid conflicts with option82 data

### DIFF
--- a/core/lease-parser.js
+++ b/core/lease-parser.js
@@ -65,7 +65,7 @@ module.exports = {
 						}
 						dhcp_lease_data[ip_address].end = end_unix_time;
 					}
-					if (/ethernet/i.test(lines[l])) {
+					if (/hardware ethernet/i.test(lines[l])) {
 						if (typeof line_data_arg[2] !== "undefined") {
 							dhcp_lease_data[ip_address].mac = line_data_arg[2].replace(/;/gi, '').trim();
 


### PR DESCRIPTION
If a lease has option82-data containing the string "ethernet" Glass will fail to parse that lease. Changing the test from "ethernet" to "hardware ethernet" fixes #31 